### PR TITLE
fix(article-2): handle multiple tool uses per agent turn

### DIFF
--- a/02-documentation-generator/python/src/main.py
+++ b/02-documentation-generator/python/src/main.py
@@ -128,26 +128,31 @@ def run_agent(user_message: str):
     while response.stop_reason == "tool_use" and iterations < max_iterations:
         iterations += 1
 
-        tool_use = next((block for block in response.content if block.type == "tool_use"), None)
+        # Get ALL tool use blocks, not just the first one
+        tool_uses = [block for block in response.content if block.type == "tool_use"]
 
-        if not tool_use:
+        if not tool_uses:
             break
 
-        print(f"\n🔧 Agent using tool: {tool_use.name}")
-        print(f"   Input: {tool_use.input}")
+        # Execute all tools and collect results
+        tool_results = []
+        for tool_use in tool_uses:
+            print(f"\n🔧 Agent using tool: {tool_use.name}")
+            print(f"   Input: {tool_use.input}")
 
-        tool_result = execute_tool(tool_use.name, tool_use.input)
+            tool_result = execute_tool(tool_use.name, tool_use.input)
 
+            tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": tool_use.id,
+                "content": tool_result,
+            })
+
+        # Send all tool results back in one message
         messages.append({"role": "assistant", "content": response.content})
         messages.append({
             "role": "user",
-            "content": [
-                {
-                    "type": "tool_result",
-                    "tool_use_id": tool_use.id,
-                    "content": tool_result,
-                }
-            ],
+            "content": tool_results,
         })
 
         response = client.messages.create(

--- a/02-documentation-generator/typescript/src/index.ts
+++ b/02-documentation-generator/typescript/src/index.ts
@@ -141,27 +141,33 @@ async function runAgent(userMessage: string) {
   while (response.stop_reason === 'tool_use' && iterations < maxIterations) {
     iterations++;
 
-    const toolUseBlock = response.content.find(
+    // Get ALL tool use blocks, not just the first one
+    const toolUseBlocks = response.content.filter(
       (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use'
     );
 
-    if (!toolUseBlock) break;
+    if (toolUseBlocks.length === 0) break;
 
-    console.log(`\n🔧 Agent using tool: ${toolUseBlock.name}`);
-    console.log(`   Input: ${JSON.stringify(toolUseBlock.input, null, 2)}`);
+    // Execute all tools and collect results
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const toolUseBlock of toolUseBlocks) {
+      console.log(`\n🔧 Agent using tool: ${toolUseBlock.name}`);
+      console.log(`   Input: ${JSON.stringify(toolUseBlock.input, null, 2)}`);
 
-    const toolResult = executeTool(toolUseBlock.name, toolUseBlock.input);
+      const toolResult = executeTool(toolUseBlock.name, toolUseBlock.input);
 
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: toolUseBlock.id,
+        content: toolResult,
+      });
+    }
+
+    // Send all tool results back in one message
     messages.push({ role: 'assistant', content: response.content });
     messages.push({
       role: 'user',
-      content: [
-        {
-          type: 'tool_result',
-          tool_use_id: toolUseBlock.id,
-          content: toolResult,
-        },
-      ],
+      content: toolResults,
     });
 
     response = await client.messages.create({


### PR DESCRIPTION
Fixes the documentation generator agent that was stopping after only 1 tool call.

## Problem
The agent loop only processed the first tool use block in each response, but Claude often returns multiple tool uses in a single turn for efficiency. This caused the agent to stop prematurely.

## Solution
- TypeScript: Use `filter()` instead of `find()` to get ALL tool use blocks
- Python: Use list comprehension instead of `next()` to get ALL tool use blocks
- Both: Loop through all tool uses, collect all results, and send them back together

This enables the agent to properly handle parallel tool execution and complete multi-step tasks.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)